### PR TITLE
Update zmk,keymap.yaml

### DIFF
--- a/app/dts/bindings/zmk,keymap.yaml
+++ b/app/dts/bindings/zmk,keymap.yaml
@@ -7,12 +7,19 @@ child-binding:
   description: "A layer to be used in a keymap"
 
   properties:
-    label:
+    display-name:
       type: string
       required: false
+      description: The name of this layer to show on displays
     bindings:
       type: phandle-array
       required: true
     sensor-bindings:
       type: phandle-array
       required: false
+
+    label:
+      type: string
+      required: false
+      deprecated: true
+      description: Deprecated. Use "name" instead.


### PR DESCRIPTION
add display-name parameter to `zmk,keymap.yaml`

For my Corne in particular, I was having some issues building without the `display-name` parameter here. Forked, added, contributing back.

The file is simply merged with the latest from the zmk repo