### PR TITLE
Remove deprecated `label` key in num_word

### DIFF
--- a/app/dts/behaviors/caps_word.dtsi
+++ b/app/dts/behaviors/caps_word.dtsi
@@ -22,7 +22,6 @@
     behaviors {
         /omit-if-no-ref/ num_word: behavior_num_word {
             compatible = "zmk,behavior-caps-word";
-            label = "NUM_WORD";
             #binding-cells = <0>;
             // layers = <xx>; // to be specified in user config using "&num_word { layers = <xx>; };"
             continue-list = <BACKSPACE DELETE DOT COMMA>;


### PR DESCRIPTION
This should remove the following warning during the "West Build" stage when building new firmware:

> 'label' is marked as deprecated in 'properties:' in /__w/zmk-config/zmk-config/zmk/app/dts/bindings/behaviors/zmk,behavior-caps-word.yaml for node /behaviors/behavior_num_word.

Thanks for providing well-maintained and usable resources! I use smart-num and caps-word almost every day :)